### PR TITLE
implement utitlity class holding static variables for compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -367,3 +367,5 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+TODO.txt

--- a/app/src/app.cpp
+++ b/app/src/app.cpp
@@ -5,16 +5,26 @@
 #include <algorithm>
 #include "app_config.h"
 
+#include <variant>
+#include <unordered_map>
+
 #include "lexer.h"
 #include "expression_parser.h"
 #include "terminals.h"
-//#include "functions_real.h"
+#include "expression_stacks.h"
+#include "static_variables.h"
 #include "expression_stacks.h"
 #include "expression_compiler.h"
 #include "operators_calc.h"
 #include "expression_profiler.h"
 
 using namespace flexMC;
+
+template<class T>
+struct MyMap {
+    std::unordered_map<std::string, T> data;
+};
+
 
 int main()
 {
@@ -24,7 +34,49 @@ int main()
               << APP_VERSION_MINOR << "."
               << APP_VERSION_PATCH << std::endl;
 
-    const bool run_main = true;
+
+
+    StaticVStorage storage;
+
+    SCALAR value = 1.0;
+    const std::vector<double> values{1, 2, 3, 4};
+
+    storage.insert<SCALAR>("x", value);
+    storage.insert<VECTOR>("x", values);
+    storage.insert<SCALAR>("x", 30.0);
+    storage.insert<SCALAR>("z", 40.0);
+
+    std::cout << cType2Str(storage.cType("x")) << std::endl;
+
+    std::cout << storage.get<SCALAR>("x") << std::endl;
+    std::cout << storage.get<SCALAR>("z") << std::endl;
+
+    std::cout << std::boolalpha << storage.containsUnused() << std::endl;
+
+//    storage.insert("x", 2);
+//    storage.insert("y", 3);
+//    storage.insert("z", 4);
+//    storage.insert("myVec", values);
+
+//    std::cout << cType2Str(storage.type("x")) << std::endl;
+//
+//    double value_ = storage.getScalar("x");
+//
+//    const std::vector<double> vector_used = storage.getVector("myVec");
+//
+//    std::cout << "Unused:" << std::endl;
+//    for (const auto &[key, val]: storage.unused())
+//    {
+//        std::cout << key << ": " << "<" << cType2Str(val) << ">" << std::endl;
+//    }
+//    std::cout << "Unused end" << std::endl;
+//
+//
+//    auto vector_used_final = storage.getVector("myVec");
+//    std::cout << "Size: " << vector_used_final.size() << std::endl;
+
+
+    const bool run_main = false;
     if (run_main)
     {
 
@@ -32,7 +84,7 @@ int main()
          * "3[(3]"
          */
         const std::string program = "1 / EXP ([0.0, 1.0, 2.0] ) - 1";
-        const std::string program_err = "(1,2])";
+        const std::string program_err = "EXP(0.0)";
         auto current = program_err;
         std::cout << "Program to parse >>" << std::endl;
         std::cout << current << std::endl << std::endl;
@@ -72,19 +124,19 @@ int main()
                 }
                 else
                 {
-                    Operands::Type return_type = reports.second.ret_type;
+                    CType return_type = reports.second.ret_type;
 
-                    std::cout << "Compiled >> Return type: " << Operands::type2Str(return_type) << std::endl;
+                    std::cout << "Compiled >> Return type: " << cType2Str(return_type) << std::endl;
 
                     CalcStacks c_stacks(0, 0, 0, 0);
 
                     expression.evaluate(c_stacks);
-                    if (c_stacks.size(Operands::Type::scalar) == 1)
+                    if (c_stacks.size(CType::scalar) == 1)
                     {
                         std::cout << "Double result: " << c_stacks.scalarsBack() << std::endl;
                         c_stacks.popScalar();
                     }
-                    else if (c_stacks.size(Operands::Type::vector) == 1)
+                    else if (c_stacks.size(CType::vector) == 1)
                     {
                         std::cout << "Vector result:" << std::endl << "[ ";
                         std::vector<double> res = c_stacks.vectorsBack();

--- a/flexmc/src/CMakeLists.txt
+++ b/flexmc/src/CMakeLists.txt
@@ -1,8 +1,11 @@
 set(SOURCES
         terminals.h
+        utils.h
         tokens.cpp
         lexer.cpp
+        calc_types.cpp
         language_error.cpp
+        expression/static_variables.h
         expression/expression_parser.cpp
         expression/expression_compiler.cpp
         expression/expression_stacks.cpp
@@ -10,7 +13,6 @@ set(SOURCES
         expression/operations/operation_compiler.cpp
         expression/operations/functions_real.cpp
         expression/operations/operators_calc.cpp
-        utils.h
 )
 
 add_library(flexmc STATIC ${SOURCES})

--- a/flexmc/src/calc_types.cpp
+++ b/flexmc/src/calc_types.cpp
@@ -1,0 +1,27 @@
+#include "calc_types.h"
+
+namespace flexMC
+{
+
+    std::string cType2Str(const CType &type)
+    {
+        using
+        enum CType;
+        switch (type)
+        {
+            case scalar:
+                return "Scalar";
+            case vector:
+                return "Vector";
+            case date:
+                return "Date";
+            case dateList:
+                return "DateList";
+            case undefined:
+                return "undefined";
+            default:
+                return "";
+        }
+    }
+
+}

--- a/flexmc/src/calc_types.h
+++ b/flexmc/src/calc_types.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <vector>
+#include <string>
+#include <unordered_map>
+
+namespace flexMC
+{
+
+    using SCALAR = double;
+    using VECTOR = std::vector<SCALAR>;
+    using DATE = int;
+    using DATE_LIST = std::vector<DATE>;
+
+    enum class CType
+    {
+        scalar,
+        date,
+        vector,
+        dateList,
+        undefined
+    };
+
+    struct CTypeHash
+    {
+
+        using is_transparent [[maybe_unused]] = void;
+
+        inline size_t operator()(const CType &c) const
+        {
+            return static_cast<size_t>(c);
+        }
+
+    };
+
+    template<class T>
+    using CTypeMap = std::unordered_map<CType, T, CTypeHash, std::equal_to<>>;
+
+    template<class T>
+    struct CTypeMapper
+    {
+        static constexpr CType value = CType::undefined;
+    };
+
+    template<>
+    struct CTypeMapper<SCALAR>
+    {
+        static constexpr CType value = CType::scalar;
+    };
+
+    template<>
+    struct CTypeMapper<VECTOR>
+    {
+        static constexpr CType value = CType::vector;
+    };
+
+    template<>
+    struct CTypeMapper<DATE>
+    {
+        static constexpr CType value = CType::date;
+    };
+
+    template<>
+    struct CTypeMapper<DATE_LIST>
+    {
+        static constexpr CType value = CType::dateList;
+    };
+
+    template<class T>
+    constexpr CType getCType()
+    {
+        static_assert(CTypeMapper<T>::value != CType::undefined, "Type T does not map to a valid CType");
+        return CTypeMapper<T>::value;
+    }
+
+    std::string cType2Str(const CType &type);
+
+}

--- a/flexmc/src/expression/expression_compiler.cpp
+++ b/flexmc/src/expression/expression_compiler.cpp
@@ -22,7 +22,7 @@ namespace flexMC
         std::pair<MaybeError, CompileReport> makeReport(MaybeError &report, const Operands &operands)
         {
             using
-            enum Operands::Type;
+            enum CType;
             if (report.isError())
             {
                 return std::make_pair(report, CompileReport(undefined, 0, 0));
@@ -71,12 +71,12 @@ namespace flexMC
             }
             else if (t == Token::Type::append_)
             {
-                Operands::Type elem_t = compileVector(tok.context.num_args, operands, report);
+                const CType elem_t = compileVector(tok.context.num_args, operands, report);
                 if (report.isError())
                 {
                     report.setPosition(tok.start, 1);
                 }
-                else if (elem_t == Operands::Type::scalar)
+                else if (elem_t == CType::scalar)
                 {
                     auto v = Vector(tok.context.num_args);
                     expression.addItem<Vector>(v);

--- a/flexmc/src/expression/expression_compiler.h
+++ b/flexmc/src/expression/expression_compiler.h
@@ -5,6 +5,7 @@
 #include <utility>
 
 #include "tokens.h"
+#include "calc_types.h"
 #include "language_error.h"
 #include "expression_stacks.h"
 
@@ -31,12 +32,12 @@ namespace flexMC
 
     struct CompileReport
     {
-        CompileReport(Operands::Type ret_t,
+        CompileReport(CType ret_t,
                       const size_t &max_s,
                       const size_t &max_v) : ret_type(ret_t), max_scalar(max_s), max_vector(max_v)
         {}
 
-        const Operands::Type ret_type;
+        const CType ret_type;
 
         const size_t max_scalar;
 

--- a/flexmc/src/expression/expression_stacks.cpp
+++ b/flexmc/src/expression/expression_stacks.cpp
@@ -1,15 +1,14 @@
 #include <cassert>
-#include <string>
 
 #include "expression_stacks.h"
 
 namespace flexMC
 {
 
-    void Operands::pushType(const Type &type)
+    void Operands::pushType(const CType &type)
     {
         using
-        enum Type;
+        enum CType;
         assert((type == scalar) || (type == date));
         if (type == scalar)
         {
@@ -19,10 +18,10 @@ namespace flexMC
         types_.push_back(type);
     }
 
-    void Operands::pushArray(const Type &type, const size_t &size)
+    void Operands::pushArray(const CType &type, const size_t &size)
     {
         using
-        enum Type;
+        enum CType;
         assert((type == vector) || (type == dateList));
         types_.push_back(type);
         vector_sizes_.push_back(size);
@@ -36,9 +35,9 @@ namespace flexMC
     void Operands::popType()
     {
         using
-        enum Type;
+        enum CType;
         assert(!types_.empty());
-        Type back = types_.back();
+        CType back = types_.back();
         if ((back == vector) || (back == dateList))
         {
             assert(!vector_sizes_.empty());
@@ -58,39 +57,18 @@ namespace flexMC
         types_.pop_back();
     }
 
-    size_t Operands::maxSize(const Type &type) const
+    size_t Operands::maxSize(const CType &type) const
     {
         switch (type)
         {
-            case Type::scalar:
+            case CType::scalar:
                 return scalar_size_max_;
-            case Type::vector:
+            case CType::vector:
                 return vec_size_max_;
             default:
                 return 0;
         }
 
-    }
-
-    std::string Operands::type2Str(const Type &type)
-    {
-        using
-        enum Type;
-        switch (type)
-        {
-            case scalar:
-                return "Scalar";
-            case vector:
-                return "Vector";
-            case date:
-                return "Date";
-            case dateList:
-                return "DateList";
-            case undefined:
-                return "undefined";
-            default:
-                return "";
-        }
     }
 
     CalcStacks::CalcStacks(const size_t &s_size, const size_t &v_size, const size_t &d_size, const size_t &d_l_size)
@@ -102,10 +80,10 @@ namespace flexMC
     }
 
 
-    size_t CalcStacks::size(Operands::Type type) const
+    size_t CalcStacks::size(const CType &type) const
     {
         using
-        enum Operands::Type;
+        enum CType;
         switch (type)
         {
             case scalar:
@@ -125,7 +103,7 @@ namespace flexMC
     bool CalcStacks::ready() const
     {
         using
-        enum Operands::Type;
+        enum CType;
         size_t not_ready{0};
         not_ready += size(scalar);
         not_ready += size(vector);

--- a/flexmc/src/expression/expression_stacks.h
+++ b/flexmc/src/expression/expression_stacks.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <vector>
+#include <string>
 
 #include "tokens.h"
+#include "calc_types.h"
 
 namespace flexMC
 {
@@ -12,25 +14,16 @@ namespace flexMC
 
     public:
 
-        enum class Type
-        {
-            scalar,
-            date,
-            vector,
-            dateList,
-            undefined
-        };
-
         [[nodiscard]] bool haveCompiled() const
         { return ((types_.size() == 1) && (functions_.empty())); }
 
-        void pushType(const Type &type);
+        void pushType(const CType &type);
 
         void popType();
 
-        void pushArray(const Type &type, const size_t &size);
+        void pushArray(const CType &type, const size_t &size);
 
-        [[nodiscard]] Type typesBack() const
+        [[nodiscard]] CType typesBack() const
         { return types_.back(); }
 
         [[nodiscard]] size_t sizesBack() const
@@ -51,13 +44,11 @@ namespace flexMC
         [[nodiscard]] size_t fSize() const
         { return functions_.size(); }
 
-        [[nodiscard]] size_t maxSize(const Type &type) const;
-
-        static std::string type2Str(const Type &type);
+        [[nodiscard]] size_t maxSize(const CType &type) const;
 
     private:
 
-        std::vector<Type> types_;
+        std::vector<CType> types_;
 
         std::vector<Token> functions_;
 
@@ -82,7 +73,7 @@ namespace flexMC
 
         bool ready() const;
 
-        size_t size(Operands::Type type) const;
+        size_t size(const CType &type) const;
 
         inline void pushScalar(const double &value)
         { scalars_.push_back(value); }

--- a/flexmc/src/expression/operand.cpp
+++ b/flexmc/src/expression/operand.cpp
@@ -1,12 +1,15 @@
 #include <cassert>
 #include <stdexcept>
+#include <iostream>
+
 #include "operand.h"
+#include "calc_types.h"
 
 
 namespace flexMC
 {
 
-    double compileNumber(const Token& token, Operands &stacks, MaybeError &report)
+    double compileNumber(const Token &token, Operands &stacks, MaybeError &report)
     {
         double value_{1.0};
         try
@@ -18,17 +21,18 @@ namespace flexMC
         }
         if (!report.isError())
         {
-            stacks.pushType(Operands::Type::scalar);
+            stacks.pushType(CType::scalar);
         }
         return value_;
     }
 
-    Operands::Type compileVector(const size_t &num_args, Operands &stacks, MaybeError &report)
+    CType compileVector(const size_t &num_args, Operands &stacks, MaybeError &report)
     {
         assert(num_args > 0);
         assert(stacks.tSize() >= num_args);
-        using enum Operands::Type;
-        const Operands::Type last_t = stacks.typesBack();
+        using
+        enum CType;
+        const CType last_t = stacks.typesBack();
         if ((last_t == dateList) || (last_t == vector))
         {
             report.setMessage("List cannot not contain another list (Matrices not allowed)");
@@ -53,7 +57,7 @@ namespace flexMC
 
     void Vector::evaluate(CalcStacks &stacks)
     {
-        assert(stacks.size(Operands::Type::scalar) >= size_);
+        assert(stacks.size(CType::scalar) >= size_);
         std::vector<double> res(stacks.scalarsEnd() - size_, stacks.scalarsEnd());
         for (size_t i{0}; i < size_; ++i)
         {

--- a/flexmc/src/expression/operand.h
+++ b/flexmc/src/expression/operand.h
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "tokens.h"
+#include "calc_types.h"
 #include "language_error.h"
 #include "expression_stacks.h"
 
@@ -14,7 +15,7 @@ namespace flexMC
 
     double compileNumber(const Token &token, Operands &stacks, MaybeError &report);
 
-    Operands::Type compileVector(const size_t &num_args, Operands &stacks, MaybeError &report);
+    CType compileVector(const size_t &num_args, Operands &stacks, MaybeError &report);
 
     class Number final : public PostFixItem
     {

--- a/flexmc/src/expression/operations/functions_real.cpp
+++ b/flexmc/src/expression/operations/functions_real.cpp
@@ -7,19 +7,19 @@
 namespace flexMC::functionsReal
 {
 
-    Operands::Type
-    compileArgType(const Token &token, const Operands::Type &arg_type, MaybeError &report)
+    CType
+    compileArgType(const Token &token, const CType &arg_type, MaybeError &report)
     {
         using
-        enum Operands::Type;
+        enum CType;
         if ((arg_type == date) || (arg_type == dateList))
         {
             auto msg = fmt::format(
                     R"(Function "{}" expects argument type {} or {}, got {})",
                     token.value,
-                    Operands::type2Str(scalar),
-                    Operands::type2Str(vector),
-                    Operands::type2Str(arg_type)
+                    cType2Str(scalar),
+                    cType2Str(vector),
+                    cType2Str(arg_type)
             );
             report.setError(msg, token.start, token.size);
             return undefined;
@@ -27,8 +27,8 @@ namespace flexMC::functionsReal
         return arg_type;
     }
 
-    std::string scalar::makeKey(const std::string &symbol, const Operands::Type &arg_type)
-    { return symbol + "_" + Operands::type2Str(arg_type); }
+    std::string scalar::makeKey(const std::string &symbol, const CType &arg_type)
+    { return symbol + "_" + cType2Str(arg_type); }
 
     std::function<void(CalcStacks &)> scalar::get(const std::string_view key)
     {
@@ -55,7 +55,7 @@ namespace flexMC::functionsReal
 
     void reduceVector::max(CalcStacks &stacks)
     {
-        assert(stacks.size(Operands::Type::vector) > 0);
+        assert(stacks.size(CType::vector) > 0);
         const auto it = std::ranges::max_element(stacks.vectorsBack());
         stacks.pushScalar(*it);
         stacks.popVector();
@@ -63,7 +63,7 @@ namespace flexMC::functionsReal
 
     void reduceVector::min(CalcStacks &stacks)
     {
-        assert(stacks.size(Operands::Type::vector) > 0);
+        assert(stacks.size(CType::vector) > 0);
         const auto it = std::ranges::min_element(stacks.vectorsBack());
         stacks.pushScalar(*it);
         stacks.popVector();
@@ -71,7 +71,7 @@ namespace flexMC::functionsReal
 
     void reduceVector::argmax(CalcStacks &stacks)
     {
-        assert(stacks.size(Operands::Type::vector) > 0);
+        assert(stacks.size(CType::vector) > 0);
         const std::vector<double> &back = stacks.vectorsBack();
         const auto res = std::ranges::distance(back.cbegin(), std::ranges::max_element(back));
         stacks.pushScalar(static_cast<double>(res));
@@ -80,7 +80,7 @@ namespace flexMC::functionsReal
 
     void reduceVector::argmin(CalcStacks &stacks)
     {
-        assert(stacks.size(Operands::Type::vector) > 0);
+        assert(stacks.size(CType::vector) > 0);
         const std::vector<double> &back = stacks.vectorsBack();
         const auto res = std::ranges::distance(back.cbegin(), std::ranges::min_element(back));
         stacks.pushScalar(static_cast<double>(res));
@@ -89,7 +89,7 @@ namespace flexMC::functionsReal
 
     void reduceVector::length(CalcStacks &stacks)
     {
-        assert(stacks.size(Operands::Type::vector) > 0);
+        assert(stacks.size(CType::vector) > 0);
         const auto res = stacks.vectorsBack().size();
         stacks.pushScalar(static_cast<double>(res));
         stacks.popVector();
@@ -97,7 +97,7 @@ namespace flexMC::functionsReal
 
     void reduceArguments::argMaxScalars(CalcStacks &stacks, const size_t &size)
     {
-        assert(stacks.size(Operands::Type::scalar) >= size);
+        assert(stacks.size(CType::scalar) >= size);
         const std::vector<double>::const_iterator end = stacks.scalarsEnd();
         const std::vector<double>::const_iterator begin = end - size;
         const auto res = std::distance(begin, std::max_element(begin, end));
@@ -108,7 +108,7 @@ namespace flexMC::functionsReal
 
     void reduceArguments::argMinScalars(CalcStacks &stacks, const size_t &size)
     {
-        assert((size > 0) && (stacks.size(Operands::Type::scalar) >= size));
+        assert((size > 0) && (stacks.size(CType::scalar) >= size));
         const std::vector<double> temp(stacks.scalarsEnd() - size, stacks.scalarsEnd());
         const auto res = std::distance(temp.cbegin(), std::ranges::min_element(temp));
         for (size_t i{0}; i < size; ++i)

--- a/flexmc/src/expression/operations/functions_real.h
+++ b/flexmc/src/expression/operations/functions_real.h
@@ -2,10 +2,9 @@
 
 #include <functional>
 #include <numeric>
-#include <string_view>
 
-#include "terminals.h"
 #include "tokens.h"
+#include "calc_types.h"
 #include "language_error.h"
 #include "expression_stacks.h"
 
@@ -13,7 +12,7 @@
 namespace flexMC::functionsReal
 {
 
-    Operands::Type compileArgType(const Token &token, const Operands::Type &arg_type, MaybeError &report);
+    CType compileArgType(const Token &token, const CType &arg_type, MaybeError &report);
 
     const std::vector<std::string> symbols_scalar{
             EXP,
@@ -38,10 +37,10 @@ namespace flexMC::functionsReal
 
         std::function<void(CalcStacks &)> get(const std::string_view key);
 
-        std::string makeKey(const std::string &symbol, const Operands::Type &arg_type);
+        std::string makeKey(const std::string &symbol, const CType &arg_type);
 
         using
-        enum Operands::Type;
+        enum CType;
 
         template<class scalar_function>
         void calculateScalar(CalcStacks &stacks, scalar_function f)
@@ -60,7 +59,7 @@ namespace flexMC::functionsReal
             std::ranges::transform(back, back.begin(), f);
         }
 
-        const std::unordered_map<std::string, std::function<void(CalcStacks &)>, SHash, std::equal_to<>> functions{
+        const StringMap<std::function<void(CalcStacks &)>> functions{
                 {
                         makeKey(flexMC::EXP, scalar),
                         [capture0 = [](const double &val)
@@ -132,27 +131,27 @@ namespace flexMC::functionsReal
 
         void max(CalcStacks &stacks);
 
-        void min(CalcStacks & stacks);
+        void min(CalcStacks &stacks);
 
-        void argmax(CalcStacks & stacks);
+        void argmax(CalcStacks &stacks);
 
-        void argmin(CalcStacks & stacks);
+        void argmin(CalcStacks &stacks);
 
-        void length(CalcStacks & stacks);
+        void length(CalcStacks &stacks);
 
         template<class binary_function>
         void accumulateVector(CalcStacks &stacks,
                               binary_function f,
                               double init)
         {
-            assert(stacks.size(Operands::Type::vector) > 0);
+            assert(stacks.size(CType::vector) > 0);
             const std::vector<double> &back = stacks.vectorsBack();
             const double res = std::accumulate(back.cbegin(), back.cend(), init, f);
             stacks.popVector();
             stacks.pushScalar(res);
         }
 
-        const std::unordered_map<std::string, std::function<void(CalcStacks &)>, SHash, std::equal_to<>> functions{
+        const StringMap<std::function<void(CalcStacks &)>> functions{
                 {
                         flexMC::SUM,
                         [capture0 = [](const double &left, const double &right)
@@ -210,7 +209,7 @@ namespace flexMC::functionsReal
                                double init,
                                const size_t &size)
         {
-            assert(stacks.size(Operands::Type::scalar) >= size);
+            assert(stacks.size(CType::scalar) >= size);
             for (size_t i{0}; i < size; ++i)
             {
                 init = f(init, stacks.scalarsBack());
@@ -224,7 +223,7 @@ namespace flexMC::functionsReal
                     binary_function f,
                     const size_t &size)
         {
-            assert(stacks.size(Operands::Type::scalar) >= size);
+            assert(stacks.size(CType::scalar) >= size);
             double found = stacks.scalarsBack();
             stacks.popScalar();
             for (size_t i{1}; i < size; ++i)
@@ -239,8 +238,7 @@ namespace flexMC::functionsReal
             stacks.pushScalar(found);
         }
 
-        const std::unordered_map
-                <std::string, std::function<void(CalcStacks &, const size_t &size)>, SHash, std::equal_to<>> functions{
+        const StringMap<std::function<void(CalcStacks &, const size_t &size)>> functions{
                 {
                         flexMC::SUM,
                         [capture0 = [](const double &left, const double &right)

--- a/flexmc/src/expression/operations/operation_compiler.cpp
+++ b/flexmc/src/expression/operations/operation_compiler.cpp
@@ -38,13 +38,13 @@ namespace flexMC
                                             MaybeError &report)
     {
         assert(stacks.tSize() >= num_args);
-        const Operands::Type arg_type = stacks.tSize() > 0 ? stacks.typesBack() : Operands::Type::scalar;
+        const CType arg_type = stacks.tSize() > 0 ? stacks.typesBack() : CType::scalar;
         assertNumberOfArgs(function, 1, num_args, arg_type, report);
         if (report.isError())
         {
             return Operation(std::function<void(CalcStacks &)>({}));
         }
-        const Operands::Type return_type = functionsReal::compileArgType(function, arg_type, report);
+        const CType return_type = functionsReal::compileArgType(function, arg_type, report);
         if (report.isError())
         {
             return Operation(std::function<void(CalcStacks &)>({}));
@@ -61,15 +61,15 @@ namespace flexMC
                                             MaybeError &report)
     {
         using
-        enum Operands::Type;
+        enum CType;
         assert(stacks.tSize() >= num_args);
-        const Operands::Type dummy_arg_type = stacks.tSize() > 0 ? stacks.typesBack() : Operands::Type::scalar;
+        const CType dummy_arg_type = stacks.tSize() > 0 ? stacks.typesBack() : scalar;
         assertNumberOfArgs(function, 1, 0, num_args, dummy_arg_type, report);
         if (report.isError())
         {
             return Operation(std::function<void(CalcStacks &)>({}));
         }
-        const Operands::Type arg_type = functionsReal::compileArgType(function, stacks.typesBack(), report);
+        const CType arg_type = functionsReal::compileArgType(function, stacks.typesBack(), report);
         if (report.isError())
         {
             return Operation(std::function<void(CalcStacks &)>({}));
@@ -113,13 +113,13 @@ namespace flexMC
     void functionCompiler::assertNumberOfArgs(const Token &function,
                                               const size_t &expected,
                                               const size_t &num_args,
-                                              const Operands::Type &arg_type,
+                                              const CType &arg_type,
                                               MaybeError &report)
     {
         if (expected != num_args)
         {
             auto msg = fmt::format(R"(Function "{}" with argument type <{}> takes exactly {} argument(s), got {})",
-                                   function.value, Operands::type2Str(arg_type), expected, num_args);
+                                   function.value, cType2Str(arg_type), expected, num_args);
             report.setError(msg, function.start, function.size);
         }
     }
@@ -128,7 +128,7 @@ namespace flexMC
                                               const size_t &min_args,
                                               const size_t &max_args,
                                               const size_t &num_args,
-                                              const Operands::Type &arg_type,
+                                              const CType &arg_type,
                                               MaybeError &report)
     {
         if ((num_args < min_args) || ((max_args > 0) && (num_args > max_args)))
@@ -138,14 +138,14 @@ namespace flexMC
             {
                 msg = fmt::format(
                         R"(Function "{}" with argument type <{}> takes between {} and {} argument(s), got {})",
-                        function.value, Operands::type2Str(arg_type), min_args, max_args, num_args
+                        function.value, cType2Str(arg_type), min_args, max_args, num_args
                 );
             }
             else
             {
                 msg = fmt::format(
                         R"(Function "{}" with argument type <{}> takes at least {} argument(s), got {})",
-                        function.value, Operands::type2Str(arg_type), min_args, num_args
+                        function.value, cType2Str(arg_type), min_args, num_args
                 );
             }
             report.setError(msg, function.start, function.size);
@@ -169,14 +169,14 @@ namespace flexMC
         if (token.context.is_prefix && operatorsCalc::isBinarySymbol(token.value))
         {
             // reports error if symbol != MINUS, expression compiler ignores PLUS before
-            const Operands::Type t = operatorsCalc::unary::compileArgument(token.value, stacks, report);
+            const CType t = operatorsCalc::unary::compileArgument(token.value, stacks, report);
             if (report.isError())
             {
                 report.setPosition(token.start, token.size);
                 return Operation(std::function<void(CalcStacks &)>({}));
             }
-            assert(t == Operands::Type::scalar || t == Operands::Type::vector);
-            if (t == Operands::Type::scalar)
+            assert(t == CType::scalar || t == CType::vector);
+            if (t == CType::scalar)
             {
                 return Operation(std::function<void(CalcStacks &)>(operatorsCalc::unary::scMinus));
             }

--- a/flexmc/src/expression/operations/operation_compiler.h
+++ b/flexmc/src/expression/operations/operation_compiler.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "tokens.h"
+#include "calc_types.h"
 #include "language_error.h"
 #include "expression_stacks.h"
 #include "operation.h"
@@ -29,19 +30,19 @@ namespace flexMC
         }
 
         void assertNumberOfArgs(
-                const Token& function,
+                const Token &function,
                 const size_t &expected,
                 const std::size_t &num_args,
-                const Operands::Type& arg_type,
-                MaybeError& report);
+                const CType &arg_type,
+                MaybeError &report);
 
         void assertNumberOfArgs(
-                const Token& function,
+                const Token &function,
                 const size_t &min_args,
                 const size_t &max_args,
                 const std::size_t &num_args,
-                const Operands::Type& arg_type,
-                MaybeError& report);
+                const CType &arg_type,
+                MaybeError &report);
 
     }
 

--- a/flexmc/src/expression/operations/operators_calc.cpp
+++ b/flexmc/src/expression/operations/operators_calc.cpp
@@ -14,11 +14,10 @@ namespace flexMC
         return look_up != operatorsCalc::binary::symbols.end();
     }
 
-    Operands::Type
-    operatorsCalc::unary::compileArgument(const std::string &symbol, const Operands &stacks, MaybeError &report)
+    CType operatorsCalc::unary::compileArgument(const std::string &symbol, const Operands &stacks, MaybeError &report)
     {
         using
-        enum Operands::Type;
+        enum CType;
         assert(stacks.tSize() >= 1);
         if (symbol != flexMC::MINUS)
         {
@@ -26,12 +25,12 @@ namespace flexMC
             report.setMessage(msg);
             return undefined;
         }
-        const Operands::Type t = stacks.typesBack();
+        const CType t = stacks.typesBack();
         if ((t == date) || (t == dateList))
         {
             auto msg = fmt::format(R"(Unary operator "{}" does not support operand type: "{}")",
                                    symbol,
-                                   Operands::type2Str(t));
+                                   cType2Str(t));
             report.setMessage(msg);
             return undefined;
         }
@@ -40,7 +39,7 @@ namespace flexMC
 
     void operatorsCalc::unary::scMinus(CalcStacks &stacks)
     {
-        assert(stacks.size(Operands::Type::scalar) >= 1);
+        assert(stacks.size(CType::scalar) >= 1);
         auto res = stacks.scalarsBack() * -1;
         stacks.popScalar();
         stacks.pushScalar(res);
@@ -48,7 +47,7 @@ namespace flexMC
 
     void operatorsCalc::unary::vecMinus(CalcStacks &stacks)
     {
-        assert(stacks.size(Operands::Type::vector) >= 1);
+        assert(stacks.size(CType::vector) >= 1);
         std::vector<double> &back = stacks.vectorsBack();
         std::ranges::transform(back, back.begin(), std::negate<double>());
     }
@@ -56,27 +55,28 @@ namespace flexMC
     std::string
     operatorsCalc::binary::compileArgumentsAndKey(const std::string &symbol, Operands &stacks, MaybeError &report)
     {
-        using enum Operands::Type;
+        using
+        enum CType;
         assert(stacks.tSize() >= 2);
-        const Operands::Type right_t = stacks.typesBack();
+        const CType right_t = stacks.typesBack();
         size_t maybe_right_s = 0;
         if ((right_t == vector) || (right_t == dateList))
         {
             maybe_right_s += stacks.sizesBack();
         }
         stacks.popType();
-        const Operands::Type left_t = stacks.typesBack();
+        const CType left_t = stacks.typesBack();
 
         if ((left_t == date) || (left_t == dateList))
         {
-            const std::string t_ = Operands::type2Str(left_t);
+            const std::string t_ = cType2Str(left_t);
             auto msg = fmt::format(R"(Binary operator "{}" does not support left operand type: "{}")", symbol, t_);
             report.setMessage(msg);
             return "";
         }
         if ((right_t == date) || (right_t == dateList))
         {
-            const std::string t_ = Operands::type2Str(right_t);
+            const std::string t_ = cType2Str(right_t);
             auto msg = fmt::format(R"(Binary operator "{}" does not support right operand type: "{}")", symbol, t_);
             report.setMessage(msg);
             return "";
@@ -120,10 +120,10 @@ namespace flexMC
 
     std::string operatorsCalc::binary::makeKey(
             const std::string &symbol,
-            const Operands::Type &left_t,
-            const Operands::Type &right_t)
+            const CType &left_t,
+            const CType &right_t)
     {
-        return symbol + Operands::type2Str(left_t) + Operands::type2Str(right_t);
+        return symbol + cType2Str(left_t) + cType2Str(right_t);
     }
 
     std::function<void(CalcStacks &)> operatorsCalc::binary::get(const std::string &key)

--- a/flexmc/src/expression/operations/operators_calc.h
+++ b/flexmc/src/expression/operations/operators_calc.h
@@ -9,6 +9,7 @@
 
 #include "utils.h"
 #include "terminals.h"
+#include "calc_types.h"
 #include "language_error.h"
 #include "expression_stacks.h"
 
@@ -22,7 +23,7 @@ namespace flexMC::operatorsCalc
     namespace unary
     {
 
-        Operands::Type compileArgument(const std::string &symbol, const Operands &stacks, MaybeError &report);
+        CType compileArgument(const std::string &symbol, const Operands &stacks, MaybeError &report);
 
         void scMinus(CalcStacks &stacks);
 
@@ -44,7 +45,7 @@ namespace flexMC::operatorsCalc
 
         std::function<void(CalcStacks &)> get(const std::string &key);
 
-        std::string makeKey(const std::string &symbol, const Operands::Type &left_t, const Operands::Type &right_t);
+        std::string makeKey(const std::string &symbol, const CType &left_t, const CType &right_t);
 
         template<class binary_operator>
         void scSc(CalcStacks &stacks, const binary_operator f)
@@ -87,7 +88,7 @@ namespace flexMC::operatorsCalc
         template<class binary_operator>
         void vecVec(CalcStacks &stacks, binary_operator f)
         {
-            assert(stacks.size(Operands::Type::vector) >= 2);
+            assert(stacks.size(CType::vector) >= 2);
             const std::vector<double> &right = stacks.vectorsBack();
             std::vector<double> &left = stacks.vectorsBeforeBack();
             std::ranges::transform(
@@ -101,7 +102,7 @@ namespace flexMC::operatorsCalc
         }
 
         using
-        enum Operands::Type;
+        enum CType;
 
         const std::unordered_map<std::string, std::function<void(CalcStacks &)>, SHash, std::equal_to<>> operators = {
                 {

--- a/flexmc/src/expression/static_variables.h
+++ b/flexmc/src/expression/static_variables.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <cassert>
+#include <vector>
+#include <variant>
+
+#include "calc_types.h"
+#include "utils.h"
+
+namespace flexMC
+{
+
+    class StaticVStorage
+    {
+
+    public:
+
+        bool contains(const std::string &name) const
+        { return types_.contains(name); }
+
+        CType cType(const std::string &name) const
+        { return types_.at(name); }
+
+        bool containsUnused() const
+        { return unused_.begin() != unused_.end(); }
+
+        StringMap<CType> unused() const
+        { return unused_; }
+
+        template<class T>
+        void insert(const std::string &name, const T &value)
+        {
+            const CType c_type = getCType<T>();
+            eraseOtherTypeIf<T>(name);
+            types_[name] = c_type;
+            unused_[name] = c_type;
+            std::get<VMap<T>>
+                    (maps_.at(c_type)).data[name] = value;
+        }
+
+        template<class T>
+        T &get(const std::string &name)
+        {
+            const CType c_type = getCType<T>();
+            use(name);
+            return std::get<VMap<T>>
+                    (maps_.at(c_type)).data.at(name);
+        }
+
+    private:
+
+        template<class T>
+        struct VMap
+        {
+            StringMap<T> data;
+        };
+
+        using VMapT = std::variant<VMap<SCALAR>, VMap<VECTOR>, VMap<DATE>, VMap<DATE_LIST>>;
+
+        CTypeMap<VMapT> maps_ = initialize();
+
+        StringMap<CType> types_;
+
+        StringMap<CType> unused_;
+
+        CTypeMap<VMapT> initialize() const
+        {
+            VMap<SCALAR> scalars;
+            VMap<VECTOR> vectors;
+            VMap<DATE> dates;
+            VMap<DATE_LIST> date_lists;
+            VMapT scalars_v = scalars;
+            VMapT vectors_v = vectors;
+            VMapT dates_v = dates;
+            VMapT date_lists_v = date_lists;
+            CTypeMap<VMapT> maps;
+            using
+            enum CType;
+            maps[scalar] = scalars_v;
+            maps[vector] = vectors_v;
+            maps[date] = dates_v;
+            maps[dateList] = date_lists_v;
+            return maps;
+        }
+
+        void use(const std::string &name)
+        {
+            if (unused_.contains(name))
+            {
+                unused_.erase(name);
+            }
+        }
+
+        template<class T>
+        void eraseOtherTypeIf(const std::string &name)
+        {
+            if (types_.contains(name))
+            {
+                const CType c_type = types_.at(name);
+                if (c_type != getCType<T>())
+                {
+                    std::visit(
+                            [name](auto &map)
+                            {
+                                if (map.data.contains(name))
+                                { map.data.erase(name); }
+                            },
+                            maps_.at(c_type));
+
+                    use(name);
+                    types_.erase(name);
+                }
+            }
+        }
+
+    };
+
+
+}

--- a/flexmc/src/utils.h
+++ b/flexmc/src/utils.h
@@ -1,14 +1,20 @@
 #pragma once
 
 #include <string_view>
+#include <unordered_map>
 
-
-struct SHash
+namespace flexMC
 {
 
-    using is_transparent [[maybe_unused]] = void;
+    struct SHash
+    {
+        using is_transparent [[maybe_unused]] = void;
 
-    inline size_t operator()(const std::string_view s_view) const
-    { return std::hash<std::string_view>{}(s_view); }
+        inline size_t operator()(const std::string_view s_view) const
+        { return std::hash<std::string_view>{}(s_view); }
+    };
 
-};
+    template<class T>
+    using StringMap = std::unordered_map<std::string, T, SHash, std::equal_to<>>;
+
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ set(TEST_SOURCES
         test_lexer.cpp
         test_expression_parser.cpp
         test_expression_compiler.cpp
+        test_unit_static_variable_storage.cpp
 )
 
 add_executable(tests ${TEST_SOURCES})

--- a/tests/test_unit_static_variable_storage.cpp
+++ b/tests/test_unit_static_variable_storage.cpp
@@ -1,0 +1,71 @@
+#include <gtest/gtest.h>
+
+#include "static_variables.h"
+
+
+TEST(StaticVStorage, SetGetUnused)
+{
+    using namespace flexMC;
+
+    SCALAR s{1.0};
+    VECTOR v{1.0, 2.0};
+    DATE d{1};
+    DATE_LIST d_l{1, 2};
+
+    std::string s_name{"s"};
+    std::string v_name{"v"};
+    std::string d_name{"d"};
+    std::string d_l_name{"d_l"};
+    std::string s_name_unused{"s_u"};
+    std::string v_name_unused{"v_u"};
+
+    StaticVStorage storage;
+
+    storage.insert<SCALAR>(s_name, s);
+    storage.insert<VECTOR>(v_name, v);
+    storage.insert<DATE>(d_name, d);
+    storage.insert<DATE_LIST>(d_l_name, d_l);
+    storage.insert<SCALAR>(s_name_unused, s);
+    storage.insert<VECTOR>(v_name_unused, v);
+
+    ASSERT_EQ(CType::scalar, storage.cType(s_name));
+    ASSERT_EQ(CType::vector, storage.cType(v_name));
+    ASSERT_EQ(CType::date, storage.cType(d_name));
+    ASSERT_EQ(CType::dateList, storage.cType(d_l_name));
+
+    ASSERT_EQ(6, storage.unused().size());
+
+    [[maybe_unused]] SCALAR s_get = storage.get<SCALAR>(s_name);
+    [[maybe_unused]] VECTOR v_get = storage.get<VECTOR>(v_name);
+    [[maybe_unused]] DATE d_get = storage.get<DATE>(d_name);
+    [[maybe_unused]] DATE_LIST d_l_get = storage.get<DATE_LIST>(d_l_name);
+
+    ASSERT_EQ(2, storage.unused().size());
+
+    [[maybe_unused]] SCALAR unused_s = storage.get<SCALAR>(s_name_unused);
+
+    ASSERT_EQ(v_name_unused, std::get<0>(*(storage.unused().begin())));
+    ASSERT_EQ(CType::vector, std::get<1>(*(storage.unused().begin())));
+    ASSERT_EQ(v, storage.get<VECTOR>(v_name_unused));
+    ASSERT_EQ(0, storage.unused().size());
+    ASSERT_EQ(0, storage.unused().size());
+
+    storage.insert<SCALAR>(v_name, s);
+    storage.insert<VECTOR>(d_name, v);
+    storage.insert<DATE>(d_l_name, d);
+    storage.insert<DATE_LIST>(s_name, d_l);
+
+    ASSERT_EQ(4, storage.unused().size());
+
+    ASSERT_EQ(CType::scalar, storage.cType(v_name));
+    ASSERT_EQ(CType::vector, storage.cType(d_name));
+    ASSERT_EQ(CType::date, storage.cType(d_l_name));
+    ASSERT_EQ(CType::dateList, storage.cType(s_name));
+
+    [[maybe_unused]] SCALAR s_get_ = storage.get<SCALAR>(v_name);
+    [[maybe_unused]] VECTOR v_get_ = storage.get<VECTOR>(d_name);
+    [[maybe_unused]] DATE d_get_ = storage.get<DATE>(d_l_name);
+    [[maybe_unused]] DATE_LIST d_l_get_ = storage.get<DATE_LIST>(s_name);
+
+    ASSERT_EQ(0, storage.unused().size());
+}


### PR DESCRIPTION
Adresses #19

Implement utitlity class holding maps of static variables, further development required
Static variables not yet fully implemented because it might be reasonable to replace child classes of `PostFixItem` with lambdas
